### PR TITLE
Add project wiki pages: Home, Getting Started, and Architecture

### DIFF
--- a/wiki_clone/Architecture-and-Tools.md
+++ b/wiki_clone/Architecture-and-Tools.md
@@ -1,0 +1,46 @@
+# Architecture and Tools
+
+This repository is primarily a **content-first exam prep system** with an optional **static quiz runtime**.
+
+## High-level architecture
+
+```mermaid
+flowchart TD
+    A["Syllabus-aligned Content"] --> B["Notes and Summaries"]
+    A --> C["Quizzes and Flashcards"]
+    D["Question Bank JSON"] --> E["Browser Quiz App"]
+    F["Docker Nginx Runtime"] --> E
+```
+
+## Repository structure
+
+- `Notes/` — chapter-wise conceptual explanations.
+- `QUIZ/` — chapter-wise quiz markdown files.
+- `FlashCard/` — chapter-wise memory reinforcement prompts.
+- `ISTQB_Sample_paper/` — sample paper materials.
+- `Chapter-wise-Summary.md`, `Time-Table.md` — revision and planning aids.
+- `questions.json` — structured question data consumed by the quiz frontend.
+- `index.html`, `style.css`, `script.js` — static frontend implementation.
+- `Dockerfile` — Nginx-based packaging for HTTP hosting.
+
+## Runtime model (quiz app)
+
+1. Browser loads `index.html`.
+2. `script.js` loads and processes `questions.json`.
+3. `style.css` applies UI styling.
+4. User interacts with quiz flow in-browser.
+
+No backend service is required for the default usage pattern.
+
+## Tooling used in repository
+
+- **Markdown** for educational content and documentation.
+- **HTML/CSS/JavaScript** for the quiz interface.
+- **JSON** for quiz data storage.
+- **Docker + Nginx** for portable static hosting.
+
+## Design intent
+
+- Keep prep material easy to browse chapter by chapter.
+- Separate data (`questions.json`) from UI (`script.js`, `index.html`).
+- Preserve a low-friction setup: local browser first, container optional.

--- a/wiki_clone/Getting-Started.md
+++ b/wiki_clone/Getting-Started.md
@@ -1,0 +1,62 @@
+# Getting Started
+
+This page helps you quickly start using the repository for ISTQB CTFL 4.0 preparation.
+
+## Prerequisites
+
+- Git
+- A Markdown viewer/editor (optional but useful)
+- A modern browser for the quiz web app
+- Optional: Docker, if you want containerized execution
+
+## 1) Clone the repository
+
+```bash
+git clone https://github.com/Mitesh411/ISTQB-CTFL-4.0-EXAM-PREP.git
+cd ISTQB-CTFL-4.0-EXAM-PREP
+```
+
+## 2) Start with the study guide
+
+Read:
+
+- `README.md` for exam details, chapter weightage, and study plan.
+- `Time-Table.md` and `Chapter-wise-Summary.md` for pacing and revision.
+
+Then study chapter content in:
+
+- `Notes/` (detailed concepts)
+- `QUIZ/` (chapter tests)
+- `FlashCard/` (rapid recall)
+
+## 3) Run the quiz web app (local static files)
+
+Open `index.html` in a browser, or serve the directory with any static file server.
+
+The app uses:
+
+- `index.html` (UI shell)
+- `style.css` (presentation)
+- `script.js` (quiz behavior)
+- `questions.json` (question data)
+
+## 4) Run with Docker (optional)
+
+Build and run:
+
+```bash
+docker build -f Dockerfile -t istqb-quiz .
+docker run -p 8080:80 istqb-quiz
+```
+
+Then open `http://localhost:8080`.
+
+## 5) Contribution basics
+
+Before contributing, review:
+
+- `CONTRIBUTING.md`
+- `CODE_OF_CONDUCT.md`
+- `SECURITY.md`
+
+Keep additions syllabus-aligned and chapter-organized.

--- a/wiki_clone/Home.md
+++ b/wiki_clone/Home.md
@@ -1,0 +1,34 @@
+# ISTQB CTFL 4.0 Exam Prep Wiki
+
+Welcome to the project wiki for `ISTQB-CTFL-4.0-EXAM-PREP`.
+
+## What this project provides
+
+- Structured study content for all six CTFL 4.0 syllabus chapters.
+- Chapter-wise notes, quizzes, and flashcards.
+- Sample paper references and study planning material.
+- A lightweight static quiz web app (`index.html`, `script.js`, `questions.json`) that can be run locally or in Docker.
+
+## Wiki navigation
+
+- **[Getting Started](Getting-Started)** — how to use the repository and run the quiz locally.
+- **[Architecture and Tools](Architecture-and-Tools)** — repository structure, content model, and toolchain.
+
+## Recommended learning path
+
+1. Read `README.md` for syllabus scope, exam format, and study strategy.
+2. Study `Notes/` chapter by chapter.
+3. Reinforce understanding with `QUIZ/` and `FlashCard/` content.
+4. Use `questions.json` + web UI for timed practice rounds.
+5. Revisit `Chapter-wise-Summary.md` before mock tests.
+
+## Core source files
+
+- `README.md`
+- `Chapter-wise-Summary.md`
+- `Notes/`
+- `QUIZ/`
+- `FlashCard/`
+- `questions.json`
+- `index.html`, `style.css`, `script.js`
+- `Dockerfile`, `Docker.md`


### PR DESCRIPTION
### Motivation

- Provide a browsable project wiki for the ISTQB CTFL 4.0 exam prep repository to centralize onboarding and navigation.
- Document how to run the lightweight static quiz locally and in Docker to lower setup friction.
- Clarify the repository structure and runtime model to separate content (`questions.json`) from UI (`index.html`/`script.js`) for maintainability.

### Description

- Add `wiki_clone/Home.md` as the landing wiki page with project overview, recommended learning path, and navigation links.
- Add `wiki_clone/Getting-Started.md` with prerequisites, `git clone` instructions, local static usage notes, and `docker build`/`docker run` example commands for containerized hosting.
- Add `wiki_clone/Architecture-and-Tools.md` describing the high-level architecture, a `mermaid` flowchart, repository layout, runtime model for the browser quiz app, and tooling used.
- Emphasize the static quiz stack (`index.html`, `style.css`, `script.js`, `questions.json`) and the optional `Dockerfile`/Nginx packaging.

### Testing

- No automated tests were executed for this documentation-only change.
- This change is documentation-only and does not modify executable code paths that would require automated test coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0588b9ff24832faa92418649c8977b)